### PR TITLE
cmake: change minimum required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.13)
 
 project(QTasksManager LANGUAGES CXX)
 


### PR DESCRIPTION
None of features from 3.14v are used so let's set
this version to 3.13 to be compatible with most of distros.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>