### PR TITLE
WorkPackages: add work packages manager and refactor the model class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(QTasksManager
     src/WorkPackage.cpp
     src/WorkPackagesModel.cpp
     src/UserSettings.cpp
+    src/WorkPackagesManager.cpp
     )
 
 target_compile_definitions(QTasksManager

--- a/src/WorkPackagesManager.cpp
+++ b/src/WorkPackagesManager.cpp
@@ -1,0 +1,24 @@
+// Copyright 2020 Bartosz Bilas <bartosz.bilas@hotmail.com>
+
+#include "WorkPackagesManager.h"
+#include <QDebug>
+#include <QDateTime>
+
+WorkPackagesManager::WorkPackagesManager(WorkPackagesModel *model) : QObject(),
+    mWorkPackagesModel(model) {
+    mActivityTimeTimer.reset(new QTimer);
+    mActivityTimeTimer->setInterval(1000);
+    mActivityTimeTimer->start();
+    connect(mActivityTimeTimer.data(), SIGNAL(timeout()), this, SLOT(onUpdateActivityTime()));
+}
+
+void WorkPackagesManager::onUpdateActivityTime() {
+    const WorkPackagesList *workPackagesList = mWorkPackagesModel->getWorkPackagesList();
+    for (int i = 0; i < workPackagesList->size(); i++) {
+        WorkPackage *workPackage = workPackagesList->at(i);
+        int activityTime = workPackage->activityTime() + mActivityTimeTimer->interval() / 1000;
+        if (workPackage->timerState()) {
+            mWorkPackagesModel->setData(mWorkPackagesModel->index(i, 0), activityTime, WorkPackagesModel::ActivityTime);
+        }
+    }
+}

--- a/src/WorkPackagesManager.h
+++ b/src/WorkPackagesManager.h
@@ -1,0 +1,26 @@
+// Copyright 2020 Bartosz Bilas <bartosz.bilas@hotmail.com>
+
+#ifndef WORKPACKAGESMANAGER_H
+#define WORKPACKAGESMANAGER_H
+
+#include <QObject>
+#include <QScopedPointer>
+#include <QTimer>
+#include "WorkPackagesModel.h"
+
+class WorkPackagesManager : public QObject {
+    Q_OBJECT
+
+ public:
+   explicit WorkPackagesManager(WorkPackagesModel *model);
+
+ public slots:
+   void onUpdateActivityTime();
+
+ private:
+   QScopedPointer<QTimer> mActivityTimeTimer;
+   WorkPackagesModel *mWorkPackagesModel;
+
+};
+
+#endif // WORKPACKAGESMANAGER_H

--- a/src/WorkPackagesModel.cpp
+++ b/src/WorkPackagesModel.cpp
@@ -6,26 +6,11 @@
 WorkPackagesModel::WorkPackagesModel(QObject *parent)
     : QAbstractListModel(parent) {
     loadData();
-
-    mTimer.reset(new QTimer);
-    mTimer->setInterval(1000);
-    mTimer->start();
-    connect(mTimer.data(), SIGNAL(timeout()), this, SLOT(onTimerTimeouted()));
 }
 
 WorkPackagesModel::~WorkPackagesModel() {
     for (WorkPackage *workPackage : mWorkPackages) {
         workPackage->deleteLater();
-    }
-}
-
-void WorkPackagesModel::onTimerTimeouted() {
-    for (int i = 0; i < mWorkPackages.size(); i++) {
-        WorkPackage *workPackage = mWorkPackages.at(i);
-        if (workPackage->timerState()) {
-            int seconds = workPackage->activityTime() + mTimer->interval() / 1000;
-            setData(index(i, 0), seconds, ActivityTime);
-        }
     }
 }
 
@@ -116,16 +101,16 @@ bool WorkPackagesModel::removeWorkPackage(int idx) {
     return true;
 }
 
-int WorkPackagesModel::calculateAndReturnTotalActivityTime() const {
+QString WorkPackagesModel::totalActivityTime() const {
     int totalActivityTime = 0;
     for (const auto &item : mWorkPackages)
         totalActivityTime += item->activityTime();
 
-    return totalActivityTime;
+    return QDateTime::fromSecsSinceEpoch(totalActivityTime).toUTC().toString("hh:mm:ss");
 }
 
-QString WorkPackagesModel::totalActivityTime() const {
-    return QDateTime::fromSecsSinceEpoch(calculateAndReturnTotalActivityTime()).toUTC().toString("hh:mm:ss");
+const WorkPackagesList *WorkPackagesModel::getWorkPackagesList() {
+    return &mWorkPackages;
 }
 
 bool WorkPackagesModel::addNewEmptyTask(void) {

--- a/src/WorkPackagesModel.h
+++ b/src/WorkPackagesModel.h
@@ -4,7 +4,6 @@
 #define WORKPACKAGESMODEL_H_
 
 #include <QAbstractListModel>
-#include <QTimer>
 #include <QSettings>
 #include "WorkPackage.h"
 #include "UserSettings.h"
@@ -39,20 +38,16 @@ class WorkPackagesModel : public QAbstractListModel {
     Q_INVOKABLE bool removeWorkPackage(int idx);
 
     QString totalActivityTime() const;
+    const WorkPackagesList *getWorkPackagesList();
 
  signals:
     void totalActivityTimeChanged();
 
- public slots:
-    void onTimerTimeouted();
-
  private:
     void loadData();
     void saveData();
-    int calculateAndReturnTotalActivityTime() const;
 
     WorkPackagesList mWorkPackages;
-    QScopedPointer<QTimer> mTimer;
     UserSettings mUserSettings;
 
 };

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,6 +5,7 @@
 #include <QQmlContext>
 #include "WorkPackagesModel.h"
 #include "UserSettings.h"
+#include "WorkPackagesManager.h"
 
 int main(int argc, char *argv[]) {
     QCoreApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
@@ -14,6 +15,7 @@ int main(int argc, char *argv[]) {
     qRegisterMetaTypeStreamOperators<WorkPackagesDescription>("WorkPackagesDescription");
     WorkPackagesModel workPackagesModel;
     UserSettings userSettings;
+    WorkPackagesManager workPackagesManager(&workPackagesModel);
 
     engine.rootContext()->setContextProperty("taskModel", &workPackagesModel);
     engine.rootContext()->setContextProperty("userSettings", &userSettings);


### PR DESCRIPTION
Move everything that is not related to the model into work packages
manager that's used to e.g updating activity time of active work
packages.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>