### PR TITLE
trayicon: workpackages: show popup message about the overhours

### DIFF
--- a/src/TrayIcon.cpp
+++ b/src/TrayIcon.cpp
@@ -1,6 +1,7 @@
 // Copyright 2020 Bartosz Bilas <bartosz.bilas@hotmail.com>
 
 #include <QCoreApplication>
+#include <QMessageBox>
 #include "TrayIcon.h"
 
 TrayIcon::TrayIcon(QQuickWindow *window) {
@@ -22,3 +23,11 @@ TrayIcon::TrayIcon(QQuickWindow *window) {
     show();
 }
 
+void TrayIcon::onShowOverHoursMessage(const QString &totalActivityTime) {
+    if (QSystemTrayIcon::supportsMessages() == false)
+        return;
+
+    const QString msg("Time worked: " + totalActivityTime);
+    QSystemTrayIcon::MessageIcon msgIcon = QSystemTrayIcon::MessageIcon(0);
+    showMessage("You have started overhours!", msg, msgIcon, 3000);
+}

--- a/src/TrayIcon.h
+++ b/src/TrayIcon.h
@@ -15,6 +15,9 @@ class TrayIcon : public QSystemTrayIcon {
  public:
     TrayIcon(QQuickWindow *window);
 
+ public slots:
+   void onShowOverHoursMessage(const QString &activityTime);
+
  private:
    QSharedPointer<QAction> mMinimizeWindowAction;
    QSharedPointer<QAction> mRestoreWindowAction;

--- a/src/WorkPackagesManager.h
+++ b/src/WorkPackagesManager.h
@@ -6,6 +6,7 @@
 #include <QObject>
 #include <QScopedPointer>
 #include <QTimer>
+#include <QTime>
 #include "WorkPackagesModel.h"
 
 class WorkPackagesManager : public QObject {
@@ -14,12 +15,20 @@ class WorkPackagesManager : public QObject {
  public:
    explicit WorkPackagesManager(WorkPackagesModel *model);
 
+ signals:
+   void overHoursDetected(const QString &activityTime);
+
  public slots:
    void onUpdateActivityTime();
 
  private:
+   bool isDailyWorkingTimeExceeded(const QTime &totalActivityTime);
+   void showOverHoursMessagePopUp(const QString &totalActivityTime);
+
    QScopedPointer<QTimer> mActivityTimeTimer;
    WorkPackagesModel *mWorkPackagesModel;
+   QTime mDailyWorkingTime;
+   bool mOverHoursMessagePupUpShowed;
 
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -31,6 +31,7 @@ int main(int argc, char *argv[]) {
     engine.load(url);
 
     TrayIcon trayIcon(qobject_cast<QQuickWindow *>(engine.rootObjects().value(0)));
+    QObject::connect(&workPackagesManager, &WorkPackagesManager::overHoursDetected, &trayIcon, &TrayIcon::onShowOverHoursMessage);
 
     return app.exec();
 }


### PR DESCRIPTION
That notifies the user that he works more
than the daily working time that's currently set to 8h.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>