### PR TITLE
WorkPackage: rename timerState property to active

### DIFF
--- a/src/WorkPackage.cpp
+++ b/src/WorkPackage.cpp
@@ -46,13 +46,13 @@ void WorkPackage::setActivityTime(const int activityTime) {
     emit activityTimeChanged();
 }
 
-bool WorkPackage::timerState() const {
-    return mConfig.timerState;
+bool WorkPackage::active() const {
+    return mConfig.active;
 }
 
-void WorkPackage::setTimerState(const bool timerState) {
-    mConfig.timerState = timerState;
-    emit timerStateChanged();
+void WorkPackage::setActive(const bool active) {
+    mConfig.active = active;
+    emit activeChanged();
 }
 
 const WorkPackageDescription* WorkPackage::config() {
@@ -60,11 +60,11 @@ const WorkPackageDescription* WorkPackage::config() {
 }
 
 QDataStream &operator<<(QDataStream &out, const WorkPackageDescription &v) {
-    out << v.projectName << v.taskName << v.activityTime << v.timerState;
+    out << v.projectName << v.taskName << v.activityTime << v.active;
     return out;
 }
 
 QDataStream &operator>>(QDataStream &in, WorkPackageDescription &v) {
-    in >> v.projectName >> v.taskName >> v.activityTime >> v.timerState;
+    in >> v.projectName >> v.taskName >> v.activityTime >> v.active;
     return in;
 }

--- a/src/WorkPackage.h
+++ b/src/WorkPackage.h
@@ -10,7 +10,7 @@ typedef struct {
     QString projectName = QStringLiteral("Project Name");
     QString taskName = QStringLiteral("Task Name");
     int activityTime = 0;
-    bool timerState = false;
+    bool active = false;
 } WorkPackageDescription;
 
 Q_DECLARE_METATYPE(WorkPackageDescription)
@@ -21,7 +21,7 @@ class WorkPackage : public QObject {
     Q_PROPERTY(QString projectName READ projectName WRITE setProjectName NOTIFY projectNameChanged)
     Q_PROPERTY(QString taskName READ taskName WRITE setTaskName NOTIFY taskNameChanged)
     Q_PROPERTY(int expiredTime READ activityTime WRITE setActivityTime NOTIFY activityTimeChanged)
-    Q_PROPERTY(bool timerState READ timerState WRITE setTimerState NOTIFY timerStateChanged)
+    Q_PROPERTY(bool active READ active WRITE setActive NOTIFY activeChanged)
 
  public:
     explicit WorkPackage(QObject *parent = nullptr);
@@ -39,8 +39,8 @@ class WorkPackage : public QObject {
     int activityTime() const;
     void setActivityTime(const int activityTime);
 
-    bool timerState() const;
-    void setTimerState(const bool timerState);
+    bool active() const;
+    void setActive(const bool active);
 
     const WorkPackageDescription* config();
 
@@ -51,7 +51,7 @@ class WorkPackage : public QObject {
     void projectNameChanged();
     void taskNameChanged();
     void activityTimeChanged();
-    void timerStateChanged();
+    void activeChanged();
 };
 
 Q_DECLARE_METATYPE(WorkPackage)

--- a/src/WorkPackages.qml
+++ b/src/WorkPackages.qml
@@ -62,8 +62,8 @@ WorkPackagesForm {
         anchors.fill: parent
 
         Switch {
-            checked: model.timerState
-            onCheckedChanged: model.timerState = checked
+            checked: model.active
+            onCheckedChanged: model.active = checked
         }
 
         Image {

--- a/src/WorkPackagesManager.cpp
+++ b/src/WorkPackagesManager.cpp
@@ -21,7 +21,7 @@ void WorkPackagesManager::onUpdateActivityTime() {
     for (int i = 0; i < workPackagesList->size(); i++) {
         WorkPackage *workPackage = workPackagesList->at(i);
         int activityTime = workPackage->activityTime() + mActivityTimeTimer->interval() / 1000;
-        if (workPackage->timerState()) {
+        if (workPackage->active()) {
             mWorkPackagesModel->setData(mWorkPackagesModel->index(i, 0), activityTime, WorkPackagesModel::ActivityTime);
         }
     }
@@ -56,10 +56,10 @@ void WorkPackagesManager::onScreenSaverActiveChanged(bool active) {
 
     for (int i = 0; i < workPackagesList->size(); i++) {
         if (active) {
-            workPackagesStates.insert(i, workPackagesList->at(i)->timerState());
-            mWorkPackagesModel->setData(mWorkPackagesModel->index(i, 0), false, WorkPackagesModel::TimerState);
+            workPackagesStates.insert(i, workPackagesList->at(i)->active());
+            mWorkPackagesModel->setData(mWorkPackagesModel->index(i, 0), false, WorkPackagesModel::Active);
         } else {
-            mWorkPackagesModel->setData(mWorkPackagesModel->index(i, 0), workPackagesStates.at(i), WorkPackagesModel::TimerState);
+            mWorkPackagesModel->setData(mWorkPackagesModel->index(i, 0), workPackagesStates.at(i), WorkPackagesModel::Active);
         }
     }
 }

--- a/src/WorkPackagesModel.cpp
+++ b/src/WorkPackagesModel.cpp
@@ -34,8 +34,8 @@ QVariant WorkPackagesModel::data(const QModelIndex &index, int role) const {
         return QVariant::fromValue(workPackage->taskName());
     case ActivityTime:
         return QVariant::fromValue(QDateTime::fromSecsSinceEpoch(workPackage->activityTime()).toUTC().toString("hh:mm:ss"));
-    case TimerState:
-        return QVariant::fromValue(workPackage->timerState());
+    case Active:
+        return QVariant::fromValue(workPackage->active());
     }
 
     return QVariant();
@@ -59,8 +59,8 @@ bool WorkPackagesModel::setData(const QModelIndex &index, const QVariant &value,
             workPackage->setActivityTime(QVariant(value).toInt());
             emit totalActivityTimeChanged();
             break;
-        case TimerState:
-            workPackage->setTimerState(QVariant(value).toBool());
+        case Active:
+            workPackage->setActive(QVariant(value).toBool());
             break;
         }
 
@@ -85,7 +85,7 @@ QHash<int, QByteArray> WorkPackagesModel::roleNames() const {
     names[ProjectName] = "projectName";
     names[TaskName] = "taskName";
     names[ActivityTime] = "activityTime";
-    names[TimerState] = "timerState";
+    names[Active] = "active";
 
     return names;
 }
@@ -144,7 +144,7 @@ void WorkPackagesModel::loadData() {
     for (WorkPackageDescription item : workPackages) {
         WorkPackage *workPackage = new WorkPackage(item);
         if (mUserSettings.restoreTaskSwitchStateAtStartUp() == false)
-            workPackage->setTimerState(false);
+            workPackage->setActive(false);
         mWorkPackages.append(workPackage);
     }
 }

--- a/src/WorkPackagesModel.h
+++ b/src/WorkPackagesModel.h
@@ -24,7 +24,7 @@ class WorkPackagesModel : public QAbstractListModel {
         ProjectName = Qt::UserRole + 1,
         TaskName,
         ActivityTime,
-        TimerState,
+        Active,
     };
 
     int rowCount(const QModelIndex &parent = QModelIndex()) const override;


### PR DESCRIPTION
Active is a more understandable name than timerState
that describes the actual work package state.

Signed-off-by: Bartosz Bilas <bartosz.bilas@hotmail.com>